### PR TITLE
fix not available submodule dependency

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -16,9 +16,6 @@
 [submodule "third_party/googletest"]
 	path = third_party/googletest
 	url = https://github.com/google/googletest.git
-[submodule "third_party/nervanagpu"]
-	path = third_party/nervanagpu
-	url = https://github.com/NervanaSystems/nervanagpu.git
 [submodule "third_party/benchmark"]
 	path = third_party/benchmark
 	url = https://github.com/google/benchmark.git


### PR DESCRIPTION
removed nervanagpu submodule from gitmodules
Currently, nervanagpu is not available in github.
It is already mentioned in original pytorch repo, like https://github.com/pytorch/pytorch/issues/19457
